### PR TITLE
Added better handling for forwards that might try to cross IP versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,10 +136,14 @@ func Main() int {
 
 	localFwd.SetDefaultAddrs(
 		netParseIP("127.0.0.1"),
-		netParseIP("10.0.2.100"))
+		netParseIP("::1"),
+		netParseIP("10.0.2.100"),
+		netParseIP("2001:2::100"))
 	remoteFwd.SetDefaultAddrs(
 		netParseIP("10.0.2.2"),
-		netParseIP("127.0.0.1"))
+		netParseIP("2001:2::2"),
+		netParseIP("127.0.0.1"),
+		netParseIP("2001:2::100"))
 
 	state.remoteUdpFwd = make(map[string]*FwdAddr)
 	state.remoteTcpFwd = make(map[string]*FwdAddr)

--- a/net.go
+++ b/net.go
@@ -60,14 +60,16 @@ func netParseIP(h string) net.IP {
 	return ip
 }
 
-// Deferrred Address. Either just an ip, in which case 'static' is
+// Deferrred Address. Either just an IP, in which case 'static' is
 // filled and we are done, or something we need to retrieve from DNS.
+// This may contain an IPv4 and/or IPv6 address.
 type defAddress struct {
 	sync.Mutex
 
 	// Static hardcoded IP/port OR previously retrieved one. In
 	// other words it's never empty for a valid address.
-	static  tcpip.FullAddress
+	static4 tcpip.FullAddress
+	static6 tcpip.FullAddress
 	label   string
 	fetched time.Time
 	error   error
@@ -85,109 +87,187 @@ func ParseDefAddress(ipS string, portS string) (_da *defAddress, _err error) {
 		if err != nil {
 			return nil, err
 		}
-		da.static.Port = uint16(port)
+		da.static4.Port = uint16(port)
+		da.static6.Port = uint16(port)
 	}
 
 	return da, nil
 }
 
-func (da *defAddress) SetDefaultAddr(a net.IP) {
-	if da.static.Addr == "" {
-		da.static.Addr = tcpip.Address(a)
+// hasIPv4 checks for the presence of an IPv4 address and may perform DNS resolution.
+func (da *defAddress) hasIPv4() bool {
+	if da.label != "" {
+		if da.resolve() != nil {
+			// DNS error
+			return false
+		}
+	}
+	return da.static4.Addr != ""
+}
+
+// hasIPv6 checks for the presence of an IPv6 address and may perform DNS resolution.
+func (da *defAddress) hasIPv6() bool {
+	if da.label != "" {
+		if da.resolve() != nil {
+			// DNS error
+			return false
+		}
+	}
+	return da.static6.Addr != ""
+}
+
+// SetDefaultAddr sets the IP addresses that are used if label is unset. Either argument may be omitted.
+func (da *defAddress) SetDefaultAddr(v4 net.IP, v6 net.IP) {
+	if da.static4.Addr == "" && da.static6.Addr == "" {
+		da.static4.Addr = tcpip.Address(v4).To4()
+		da.static6.Addr = tcpip.Address(v6)
 	}
 }
 
+// Retreive returns a static address or resolves the label in DNS. Prefers to return IPv4 over IPv6.
 func (da *defAddress) Retrieve() *tcpip.FullAddress {
+	if da.label == "" {
+		// Return IPv4 or IPv6
+		if da.static4.Addr != "" {
+			return &da.static4
+		}
+		return &da.static6
+	}
+
+	da.error = da.resolve()
+	if da.error != nil {
+		return nil
+	}
+
+	// Return IPv4 or IPv6
+	if da.static4.Addr != "" {
+		return &da.static4
+	}
+	return &da.static6
+}
+
+// resolve performs a DNS resolution of label and populates static4 and/or static6, or returns an error.
+// May return a cached result according to dnsTTL.
+func (da *defAddress) resolve() error {
 	da.Lock()
 	defer da.Unlock()
-	if da.label == "" || time.Now().Sub(da.fetched) <= dnsTTL {
-		return &da.static
+
+	if da.label == "" {
+		return fmt.Errorf("DNS resolution attempted on empty defAddress label")
+	}
+	if time.Now().Sub(da.fetched) <= dnsTTL {
+		return nil // Use cached result
 	}
 	da.fetched = time.Now()
 
-	ip, port, err := FullResolve(da.label)
+	ipv4, ipv6, port, err := FullResolve(da.label)
 	if err != nil {
 		// Failed to resolve
-		da.error = err
-		return nil
-	} else {
-		da.static.Addr = tcpip.Address(ip)
-		if port != 0 {
-			da.static.Port = uint16(port)
-		}
-		da.error = nil
+		return err
 	}
-	return &da.static
+	da.static4.Addr = tcpip.Address(ipv4)
+	da.static6.Addr = tcpip.Address(ipv6)
+	if port != 0 {
+		da.static4.Port = uint16(port)
+		da.static6.Port = uint16(port)
+	}
+	return nil
 }
 
+// String returns host:port of the IPv4 or IPv6 address, or host-failed on DNS resoluton failure.
+// If both IPv6 and IPv6 exist, IPv4 only is returned.
 func (da *defAddress) String() string {
 	static := da.Retrieve()
 	if static == nil {
 		return fmt.Sprintf("%s-failed", da.label)
 	}
-	return fmt.Sprintf("%s:%d", net.IP(da.static.Addr).String(), da.static.Port)
+	return fmt.Sprintf("%s:%d", net.IP(static.Addr).String(), static.Port)
 }
 
-func (da *defAddress) GetTCPAddr() *net.TCPAddr {
-	static := da.Retrieve()
-	if static == nil {
-		return nil
+// GetTCPAddr returns a TCPAddr for IPv4 and/or IPv6, or neither if DNS resolution fails.
+func (da *defAddress) GetTCPAddr() (tcpv4, tcpv6 *net.TCPAddr) {
+	if da.hasIPv4() { // hasIPv4 performs DNS resolution if necessary
+		tcpv4 = &net.TCPAddr{
+			IP:   net.IP(da.static4.Addr),
+			Port: int(da.static4.Port),
+		}
 	}
-
-	return &net.TCPAddr{
-		IP:   net.IP(static.Addr),
-		Port: int(static.Port),
+	if da.hasIPv6() {
+		tcpv6 = &net.TCPAddr{
+			IP:   net.IP(da.static6.Addr),
+			Port: int(da.static6.Port),
+		}
 	}
+	return
 }
 
-func (da *defAddress) GetUDPAddr() *net.UDPAddr {
-	static := da.Retrieve()
-	if static == nil {
-		return nil
+// GetUDPAddr returns a UDPAddr for IPv4 and/or IPv6, or neither if DNS resolution fails.
+func (da *defAddress) GetUDPAddr() (udpv4, udpv6 *net.UDPAddr) {
+	if da.hasIPv4() { // hasIPv4 performs DNS resolution if necessary
+		udpv4 = &net.UDPAddr{
+			IP:   net.IP(da.static4.Addr),
+			Port: int(da.static4.Port),
+		}
 	}
-
-	return &net.UDPAddr{
-		IP:   net.IP(static.Addr),
-		Port: int(static.Port),
+	if da.hasIPv6() {
+		udpv6 = &net.UDPAddr{
+			IP:   net.IP(da.static6.Addr),
+			Port: int(da.static6.Port),
+		}
 	}
+	return
 }
 
-func simpleLookupHost(resolver *net.Resolver, label string) (net.IP, error) {
+// simpleLookupHost resolves an IPv4 and/or IPv6 address
+func simpleLookupHost(resolver *net.Resolver, label string) (net.IP, net.IP, error) {
 	addrs, err := resolver.LookupHost(context.Background(), label)
 	if err != nil {
 		// On resolution failure, error out
-		return nil, err
+		return nil, nil, err
 	}
 	if len(addrs) < 1 {
-		return nil, fmt.Errorf("Empty dns reponse for %q", label)
+		return nil, nil, fmt.Errorf("Empty dns reponse for %q", label)
 	}
 
+	var ipv4, ipv6 net.IP
 	// prefer IPv4. No real reason.
 	for _, addr := range addrs {
 		ip := netParseIP(addr)
 		if ip.To4() != nil {
-			return ip.To4(), nil
+			if ipv4 == nil {
+				ipv4 = ip.To4()
+			}
+		} else if ip.To16() != nil {
+			if ipv6 == nil {
+				ipv6 = ip.To16()
+			}
+		}
+
+		if ipv4 != nil && ipv6 != nil {
+			return ipv4, ipv6, nil
 		}
 	}
 
-	ip := netParseIP(addrs[0])
-	if ip == nil {
-		return nil, fmt.Errorf("Empty dns reponse for %q", label)
+	if ipv4 == nil && ipv6 == nil {
+		return nil, nil, fmt.Errorf("Empty dns reponse for %q", label)
 	}
-	return ip, nil
+	return ipv4, ipv6, nil
 }
 
-func FullResolve(label string) (net.IP, uint16, error) {
+// FullResolve attempts a DNS lookup on label and returns an IPv4 and/or IPv6 result.
+// Optionally resolves the format 'label@srv-1234:0', which means to retrieve the target label
+// from DNS on localhost on port 1234 from SRV record.
+func FullResolve(label string) (net.IP, net.IP, uint16, error) {
 	port := uint16(0)
 	p := strings.SplitN(label, "@", 2)
 	if len(p) == 2 {
 		srvQuery, dnsSrv := p[0], p[1]
 		if !strings.HasPrefix(dnsSrv, "srv-") {
-			return nil, 0, fmt.Errorf("Unknown dns type %q", dnsSrv)
+			return nil, nil, 0, fmt.Errorf("Unknown dns type %q", dnsSrv)
 		}
 		dnsPort, err := strconv.ParseUint(dnsSrv[4:], 10, 16)
 		if err != nil {
-			return nil, 0, fmt.Errorf("Cant parse dns server port %q", dnsSrv[4:])
+			return nil, nil, 0, fmt.Errorf("Cant parse dns server port %q", dnsSrv[4:])
 		}
 		dnsSrvAddr := fmt.Sprintf("127.0.0.1:%d", dnsPort)
 		r := &net.Resolver{
@@ -201,7 +281,7 @@ func FullResolve(label string) (net.IP, uint16, error) {
 		}
 		_, srvAddrs, err := r.LookupSRV(context.Background(), "", "", srvQuery)
 		if err != nil || len(srvAddrs) == 0 {
-			return nil, 0, fmt.Errorf("Failed to lookup SRV %q on %q", srvQuery, dnsSrvAddr)
+			return nil, nil, 0, fmt.Errorf("Failed to lookup SRV %q on %q", srvQuery, dnsSrvAddr)
 		}
 
 		// For effective resolution, allowing to utilize
@@ -212,9 +292,9 @@ func FullResolve(label string) (net.IP, uint16, error) {
 			serviceLabel = serviceLabel[:len(serviceLabel)-1]
 		}
 
-		ip, err := simpleLookupHost(r, serviceLabel)
-		if err == nil && ip != nil {
-			return ip, servicePort, nil
+		ipv4, ipv6, err := simpleLookupHost(r, serviceLabel)
+		if err == nil && (ipv4 != nil || ipv6 != nil) {
+			return ipv4, ipv6, servicePort, nil
 		}
 
 		// Fallthrough and try the OS resolver
@@ -222,21 +302,29 @@ func FullResolve(label string) (net.IP, uint16, error) {
 		port = servicePort
 	}
 
-	ip, err := simpleLookupHost(net.DefaultResolver, label)
+	ipv4, ipv6, err := simpleLookupHost(net.DefaultResolver, label)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, 0, err
 	}
-	return ip, port, nil
+	return ipv4, ipv6, port, nil
 }
 
+// netParseOrResolveIP attempted to convert h to an IP address, otherwise performs DNS resolution.
+// If both IPv4 and IPv6 DNS records exist, the IPv4 is returned.
 func netParseOrResolveIP(h string) (_ip net.IP, _resolved bool, _err error) {
 	ip := netParseIP(h)
 	if ip != nil {
 		return ip, false, nil
 	}
 
-	ip, _, err := FullResolve(h)
-	return ip, true, err
+	ipv4, ipv6, _, err := FullResolve(h)
+	if err != nil {
+		return nil, true, err
+	}
+	if ipv4 != nil {
+		return ipv4, true, nil
+	}
+	return ipv6, true, nil
 }
 
 func OutboundDial(srcIPs *SrcIPs, dst net.Addr) (net.Conn, error) {


### PR DESCRIPTION
Fix majek/slirpnetstack#20. Implicit IP addresses are now dual-stack.  DNS resolution now stores both IPv4 and IPv6 results and attempts to only connect if they share an IP version (making `network is unreachable` into a more specific error).

Feedback is appreciated.